### PR TITLE
Added support for more association types/info

### DIFF
--- a/app/controllers/admin_data/main_controller.rb
+++ b/app/controllers/admin_data/main_controller.rb
@@ -67,19 +67,8 @@ class AdminData::MainController  < AdminData::BaseController
 
   def update
     model_name_underscored = @klass.name.underscore
-    model_attrs = params[model_name_underscored]
+    model_attrs = update_model_with_assoc(params[model_name_underscored])
     @columns = columns_list
-    
-    if AdminData::Util.habtm_what(@klass).any? then
-      AdminData::Util.habtm_what(klass).each do |k|
-        assoc_klass = AdminData::Util.get_class_name_for_habtm_association(model, k)
-        if model_attrs.include? assoc_klass.table_name then
-          model_attrs[assoc_klass.table_name].map! do |s|
-            assoc_klass.find(s.to_i)
-          end
-        end
-      end
-    end
     
     respond_to do |format|
       if @model.update_attributes(model_attrs)
@@ -97,7 +86,7 @@ class AdminData::MainController  < AdminData::BaseController
 
   def create
     model_name_underscored = @klass.name.underscore
-    model_attrs = params[model_name_underscored]
+    model_attrs = update_model_with_assoc(params[model_name_underscored])
     @model = @klass.create(model_attrs)
     @columns = columns_list
 
@@ -116,6 +105,22 @@ class AdminData::MainController  < AdminData::BaseController
   end
 
   private
+  
+  # If this class has any habtm relationships, update the parameters
+  # in the model with the actual objects so they can be saved properly
+  def update_model_with_assoc(model_attrs)
+    if AdminData::Util.habtm_what(@klass).any? then
+      AdminData::Util.habtm_what(klass).each do |k|
+        assoc_klass = AdminData::Util.get_class_name_for_habtm_association(@model || @klass, k)
+        if model_attrs.include? assoc_klass.table_name then
+          model_attrs[assoc_klass.table_name].map! do |s|
+            assoc_klass.find(s.to_i)
+          end
+        end
+      end
+    end
+    model_attrs
+  end
 
   def get_model_and_verify_it
     primary_key = @klass.primary_key.intern

--- a/app/controllers/admin_data/main_controller.rb
+++ b/app/controllers/admin_data/main_controller.rb
@@ -69,6 +69,18 @@ class AdminData::MainController  < AdminData::BaseController
     model_name_underscored = @klass.name.underscore
     model_attrs = params[model_name_underscored]
     @columns = columns_list
+    
+    if AdminData::Util.habtm_what(@klass).any? then
+      AdminData::Util.habtm_what(klass).each do |k|
+        assoc_klass = AdminData::Util.get_class_name_for_habtm_association(model, k)
+        if model_attrs.include? assoc_klass.table_name then
+          model_attrs[assoc_klass.table_name].map! do |s|
+            assoc_klass.find(s.to_i)
+          end
+        end
+      end
+    end
+    
     respond_to do |format|
       if @model.update_attributes(model_attrs)
         format.html do

--- a/app/controllers/admin_data/public_controller.rb
+++ b/app/controllers/admin_data/public_controller.rb
@@ -1,0 +1,18 @@
+
+class AdminData::PublicController < AdminData::BaseController
+
+  def serve
+    f = File.join(AdminData::Config.setting[:plugin_dir], 'lib', params[:file])
+    if not File.exists? f then
+      return render :nothing => true, :status => 404
+    end
+    opts = {:text => File.new(f).read, :cache => true}
+    if f =~ /css$/ then
+      opts[:content_type] = "text/css"
+    elsif f =~ /js$/ then
+      opts[:content_type] = "text/javascript"
+    end
+    render opts
+  end
+
+end

--- a/app/views/admin_data/main/association/_association_info.html.erb
+++ b/app/views/admin_data/main/association/_association_info.html.erb
@@ -5,6 +5,7 @@
       <%= render 'admin_data/main/association/belongs_to_info' ,  :klass => klass, :model => model %>
       <%= render 'admin_data/main/association/has_one_info',      :klass => klass, :model => model %>
       <%= render 'admin_data/main/association/has_many_info' ,    :klass => klass, :model => model %> 
+      <%= render 'admin_data/main/association/habtm_info' ,       :klass => klass, :model => model %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin_data/main/association/_habtm_info.html.erb
+++ b/app/views/admin_data/main/association/_habtm_info.html.erb
@@ -1,0 +1,7 @@
+<% if AdminData::Util.habtm_what(klass).any? %>
+  <p>
+    <strong>has_and_belongs_to_many :</strong>
+    <%= admin_data_habtm_data(model, klass).html_safe %>
+    &nbsp;
+  </p> 
+<% end %>  

--- a/app/views/admin_data/main/misc/_form.html.erb
+++ b/app/views/admin_data/main/misc/_form.html.erb
@@ -8,6 +8,12 @@
   </div>  
 <% end %>
 
+<% if AdminData::Util.habtm_what(klass).any? %>
+  <div class='data'>
+    <%= admin_data_form_field_for_habtm_records(klass, @model, f, '').html_safe %>
+  </div>
+<% end %>
+
 <div class='group navform' style='padding-top:10px;'>
   <% if params[:action] == 'edit' || params[:action] == 'update' %>
     <% label = 'Update' %>

--- a/app/views/admin_data/search/search/_listing.html.erb
+++ b/app/views/admin_data/search/search/_listing.html.erb
@@ -15,6 +15,11 @@
       <% AdminData::Util.columns_order(klass.name).each do |column| %>
         <th> <%= column %> </th>
       <% end %>
+      <% if AdminData::Util.habtm_what(klass).any? %>
+        <% AdminData::Util.habtm_what(klass).each do |k| %>
+          <th> <%= k %> </th>
+        <% end %>
+      <% end %>
     </tr>
   </thead>
 
@@ -28,6 +33,11 @@
             <%=h  admin_data_get_value_for_column(admin_data_column_native(klass, column), record) %>
           <% end %>  
         </td>
+      <% end %>
+      <% if AdminData::Util.habtm_what(klass).any? %>
+        <% AdminData::Util.habtm_what(klass).each do |k| %>
+          <td> <%= admin_data_habtm_values_for(record, k) %> </td>
+        <% end %>
       <% end %>
     </tr>
   <% end %>  

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
 
     match '/quick_search/:klass' => "search#quick_search", :as => :search
     match '/advance_search/:klass' => "search#advance_search", :as => :advance_search
+    
+    match '/public/*file' => "public#serve"
   end
 
   scope '/admin_data' do

--- a/lib/admin_data/helpers.rb
+++ b/lib/admin_data/helpers.rb
@@ -100,6 +100,28 @@ module AdminData::Helpers
     end
     array.join(', ')
   end
+  
+  def admin_data_habtm_data(model, klass)
+    array = AdminData::Util.habtm_what(klass).inject([]) do |output, hm|
+      # same as admin_data_has_many_data()
+      begin
+        label = hm + '(' + AdminData::Util.has_many_count(model,hm).to_s + ')'
+        if AdminData::Util.has_many_count(model,hm) > 0
+          has_many_klass_name = AdminData::Util.get_class_name_for_has_many_association(model,hm).name.underscore
+          output << link_to(label, admin_data_search_path(  :klass => has_many_klass_name,
+          :children => hm,
+          :base => klass.name.underscore,
+          :model_id => model.id))
+        else
+          output << label
+        end
+      rescue => e
+        Rails.logger.info AdminData::Util.exception_info(e)
+      end
+      output
+    end
+    array.join(', ')
+  end
 
   def admin_data_breadcrum(&block)
     render(:partial => '/admin_data/shared/breadcrum', :locals => {:data => capture(&block)})

--- a/lib/admin_data/helpers.rb
+++ b/lib/admin_data/helpers.rb
@@ -122,6 +122,14 @@ module AdminData::Helpers
     end
     array.join(', ')
   end
+  
+  def admin_data_habtm_values_for(model, klass)
+    assoc_klass = AdminData::Util.get_class_name_for_habtm_association(model, klass)
+    name = assoc_klass.columns.map(&:name).include?('name') ? :name : assoc_klass.primary_key
+    model.send(assoc_klass.table_name).map{ |e| 
+      link_to(e.send(name), admin_data_on_k_path(:klass => assoc_klass, :id => e.id))
+    }.join(", ").html_safe
+  end
 
   def admin_data_breadcrum(&block)
     render(:partial => '/admin_data/shared/breadcrum', :locals => {:data => capture(&block)})

--- a/lib/admin_data/helpers.rb
+++ b/lib/admin_data/helpers.rb
@@ -270,6 +270,21 @@ module AdminData::Helpers
         '<actual data is not being shown because truncate method failed.>'
       end
     else
+
+      # check for an associated class id and add it's name to the value
+      ar = model.class.reflections.values.detect{ |v| v.primary_key_name == column.name}
+      if not ar.nil? then
+        name = ar.klass.columns.map(&:name).include?('name') ? :name : ar.klass.primary_key
+        assoc = model.send(ar.name)
+        if not name.nil? then
+          value = ("#{value} (" + 
+                  link_to(
+                    assoc.send(name), 
+                    admin_data_on_k_path(:klass => ar.klass, 
+                                              :id => assoc.send(ar.klass.primary_key))) + ")").html_safe
+        end
+      end
+      
       value
     end
   end

--- a/lib/admin_data/util.rb
+++ b/lib/admin_data/util.rb
@@ -168,7 +168,8 @@ class AdminData::Util
   end
   
   def self.get_class_name_for_habtm_association(model, has_many_string)
-    data = model.class.name.camelize.constantize.reflections.values.detect do |value|
+    klass = model.kind_of?(Class) ? model : model.class
+    data = klass.name.camelize.constantize.reflections.values.detect do |value|
       value.macro == :has_and_belongs_to_many && value.name.to_s == has_many_string
     end
     data.klass if data # output of detect from hash is an array with key and value

--- a/lib/admin_data/util.rb
+++ b/lib/admin_data/util.rb
@@ -137,19 +137,19 @@ class AdminData::Util
   end
 
   def self.javascript_include_tag(*args)
-    data = args.inject('') do |sum, arg|
-      f = File.new(File.join(AdminData::Config.setting[:plugin_dir], 'lib', 'js', "#{arg}.js"))
-      sum << f.read
+    data = args.inject([]) do |sum, arg|
+      arg = "#{arg}.js" if arg !~ /js$/
+      sum << ['<script type="text/javascript" src="/admin_data/public/js/', arg, '"></script>'].join
     end
-    ['<script type="text/javascript">', data, '</script>'].join
+    data.join("\n")
   end
 
   def self.stylesheet_link_tag(*args)
-    data = args.inject('') do |sum, arg|
-      f = File.new(File.join(AdminData::Config.setting[:plugin_dir], 'lib', 'css', "#{arg}.css"))
-      sum << f.read
+    data = args.inject([]) do |sum, arg|
+      arg = "#{arg}.css" if arg !~ /css$/
+      sum << ['<link href="/admin_data/public/css/', arg, '" media="screen" rel="stylesheet" type="text/css" />'].join
     end
-    ["<style type='text/css'>", data, '</style>'].join
+    data.join("\n")
   end
 
   def self.get_class_name_for_has_many_association(model, has_many_string)

--- a/lib/admin_data/util.rb
+++ b/lib/admin_data/util.rb
@@ -51,7 +51,7 @@ class AdminData::Util
   def self.label_values_pair_for(model, view)
     data = model.class.columns.inject([]) do |sum, column|
       tmp = view.admin_data_get_value_for_column(column, model, :limit => nil)
-      sum << [column.name, view.send(:h,tmp)]
+      sum << [ column.name, (tmp.html_safe? ? tmp : view.send(:h,tmp)) ]
     end
     klass = model.class
     if habtm_what(klass).any? then
@@ -60,7 +60,10 @@ class AdminData::Util
         assoc_klass = get_class_name_for_habtm_association(model, k)
         name = assoc_klass.columns.map(&:name).include?('name') ? :name : assoc_klass.primary_key
         data << [ assoc_klass.table_name, model.send(assoc_klass.table_name).map{ |e| 
-          view.link_to(e.send(name), view.admin_data_on_k_path(:klass => assoc_klass, :id => e.id))
+          view.link_to(
+            e.send(name), 
+            view.admin_data_on_k_path(:klass => assoc_klass, 
+                                      :id => e.send(assoc_klass.primary_key)))
         }.join(", ").html_safe ]
       end
     end


### PR DESCRIPTION
Hey,

I added support has_and_belongs_to_many in the various screens. You can now choose and update these objects using a multiple select box. I also added display of other relationship data. Let me know if you have any questions.

The first commit (82f402e4) was sort of a warmup; I originally intended to start by adding a datepicker widget to the edit screen but then moved on to the other stuff. I still intend to add that feature.

chetan
