### PR TITLE
Enable direct usage of blocks in configuration 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # admin_data works with both Rails 2.3.x and Rails 3. #
+# [Documentation](http://github.com/neerajdotname/admin_data/wiki) #
 
-# [Features and Documentation](http://github.com/neerajdotname/admin_data/wiki) #
-
-# [Installing in Rails3 project](https://github.com/neerajdotname/admin_data/wiki/Installation-and-Usage-information-for-a-Rails-3-application) #
-# [Installing in Rails 2.3.x project](https://github.com/neerajdotname/admin_data/wiki/Installation-and-Usage-information-for-a-Rails-2.3.x-application) #
+# [Installing in a Rails3 application](https://github.com/neerajdotname/admin_data/wiki/Installation-and-Usage-information-for-a-Rails-3-application) #
+# [Installing in a Rails 2.3.x application](https://github.com/neerajdotname/admin_data/wiki/Installation-and-Usage-information-for-a-Rails-2.3.x-application) #
 
 # [Live Demo](http://admin-data-test.heroku.com/admin_data) #
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 # [Live Demo](http://admin-data-test.heroku.com/admin_data) #
 
 
-## Source Code ##
 * admin_data works as a gem with Rails 3.x project. Source for that resides in master branch.
 * admin_data works as a plugin with Rails 2.3.x project. Source code for that resides in branch called [rails2](https://github.com/neerajdotname/admin_data/tree/rails2) .
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # admin_data #
 
-# This plugin works with both Rails 2.3.x and Rails 3.
-* [Installing in Rails3 project](http://github.com/neerajdotname/admin_data/wiki/Installing-admin_data-in-a-Rails-3-project)
-* [Installing in Rails 2.3.x project](https://github.com/neerajdotname/admin_data/wiki/Installing-admin_data-in-a-Rails-2.3.x-project)
+# This plugin works with both Rails 2.3.x and Rails 3. #
 
-## [Live Demo](http://admin-data-test.heroku.com/admin_data)
+# [Installing in Rails3 project](https://github.com/neerajdotname/admin_data/wiki/Installation-and-Usage-information-for-a-Rails-3-application) #
+# [Installing in Rails 2.3.x project](https://github.com/neerajdotname/admin_data/wiki/Installation-and-Usage-information-for-a-Rails-2.3.x-application) #
 
-## [Documentation](http://github.com/neerajdotname/admin_data/wiki)
+# [Live Demo](http://admin-data-test.heroku.com/admin_data) #
+
+# [Documentation](http://github.com/neerajdotname/admin_data/wiki) #
 
 ## Source Code ##
 * admin_data works as a gem with Rails 3.x project. Source for that resides in master branch.
@@ -14,9 +15,9 @@
 
 #Test#
 
-cd _test/rails_app_ and read the instructions mentioned at README.md there.
+##cd _test/rails_app_ and read the instructions mentioned at README.md there. ##
 
 
-### License
+### License ###
 
 Dual licensed under the [MIT](http://github.com/jquery/jquery/blob/master/MIT-LICENSE.txt) and [GPL version 2](http://github.com/jquery/jquery/blob/master/GPL-LICENSE.txt) licenses.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
-# admin_data #
+# admin_data works with both Rails 2.3.x and Rails 3. #
 
-# This plugin works with both Rails 2.3.x and Rails 3. #
+# [Features and Documentation](http://github.com/neerajdotname/admin_data/wiki) #
 
 # [Installing in Rails3 project](https://github.com/neerajdotname/admin_data/wiki/Installation-and-Usage-information-for-a-Rails-3-application) #
 # [Installing in Rails 2.3.x project](https://github.com/neerajdotname/admin_data/wiki/Installation-and-Usage-information-for-a-Rails-2.3.x-application) #
 
 # [Live Demo](http://admin-data-test.heroku.com/admin_data) #
 
-# [Documentation](http://github.com/neerajdotname/admin_data/wiki) #
 
 ## Source Code ##
 * admin_data works as a gem with Rails 3.x project. Source for that resides in master branch.
@@ -15,7 +14,7 @@
 
 #Test#
 
-##cd _test/rails_app_ and read the instructions mentioned at README.md there. ##
+cd _test/rails_app_ and read the instructions mentioned at README.md there.
 
 
 ### License ###

--- a/lib/admin_data/configuration.rb
+++ b/lib/admin_data/configuration.rb
@@ -69,19 +69,31 @@ module AdminData
     #
     attr_accessor :columns_order
 
-    def is_allowed_to_view
-      return lambda {|controller| return true } if Rails.env.development?
-      @is_allowed_to_view || lambda {|_| nil }
+    def is_allowed_to_view &block
+      if block_given?
+        @is_allowed_to_view = block
+      else
+        return lambda {|controller| return true } if Rails.env.development?
+        @is_allowed_to_view || lambda {|_| nil }
+      end
     end
 
-    def is_allowed_to_update
-      return lambda {|controller| return true } if Rails.env.development?
-      @is_allowed_to_update || lambda {|_| nil }
+    def is_allowed_to_update &block
+      if block_given?
+        @is_allowed_to_update = block
+      else
+        return lambda {|controller| return true } if Rails.env.development?
+        @is_allowed_to_update || lambda {|_| nil }
+      end
     end
 
-    def is_allowed_to_view_feed
-      return lambda {|controller| return true } if Rails.env.development?
-      @is_allowed_to_view_feed || lambda {|_| nil }
+    def is_allowed_to_view_feed &block
+      if block_given?
+        @is_allowed_to_view_feed = block
+      else
+        return lambda {|controller| return true } if Rails.env.development?
+        @is_allowed_to_view_feed || lambda {|_| nil }
+      end
     end
 
     # TODO explain why it is needed


### PR DESCRIPTION
Currently users specify security settings by passing a proc or lambda:

`config.is_allowed_to_view = lambda {|controller| return true if Rails.env.development? }`

My commit enables the usage of blocks directly:

`config.is_allowed_to_view {|controller| return true if Rails.env.development? }`

I could not get your test cases to run, so you probably want to make sure that this doesn't break anything yourself.
