### PR TITLE
Routing error caused by id paramter being passed record object instead of record id

### DIFF
--- a/app/helpers/admin_data/application_helper.rb
+++ b/app/helpers/admin_data/application_helper.rb
@@ -288,5 +288,12 @@ module AdminData
       klass.reflections.values.detect { |reflection| reflection.primary_key_name.to_sym == col.name.to_sym }
     end
 
+    def record_id(record)
+      if record.respond_to?(:primary_key)
+        record.send(:primary_key)
+      else
+        record.id
+      end
+    end
   end
 end

--- a/app/views/admin_data/search/search/_listing.html.erb
+++ b/app/views/admin_data/search/search/_listing.html.erb
@@ -23,7 +23,7 @@
       <% columns_order(klass).each do |column| %>
         <td>
           <% if (column == klass.primary_key) %>
-            <%= link_to(record.to_param.to_s, admin_data_path(:klass => klass.name.underscore, :id => record.id)) %>
+            <%= link_to(record.to_param.to_s, admin_data_path(:klass => klass.name.underscore, :id => record_id(record))) %>
          <% else %>
             <%=h get_value_for_column(column_native(klass, column), record) %>
           <% end %>

--- a/app/views/admin_data/search/search/_listing.html.erb
+++ b/app/views/admin_data/search/search/_listing.html.erb
@@ -23,7 +23,7 @@
       <% columns_order(klass).each do |column| %>
         <td>
           <% if (column == klass.primary_key) %>
-            <%= link_to(record.to_param.to_s, admin_data_path(:klass => klass.name.underscore, :id => record)) %>
+            <%= link_to(record.to_param.to_s, admin_data_path(:klass => klass.name.underscore, :id => record.id)) %>
          <% else %>
             <%=h get_value_for_column(column_native(klass, column), record) %>
           <% end %>


### PR DESCRIPTION
I was receiving intermittent errors when paging between result sets (Rails 3.0.7). For example, pages 1 and 2 of a table's listing would be fine, then page 3 would throw a routing error with the :id param being passed the object converted to a string, ie: :id => #<User id: 1234567, login: "blah"...

Explicitly passing record.id fixed my issues.
