### PR TITLE
Rails 3.1 fixes

### DIFF
--- a/app/controllers/admin_data/public_controller.rb
+++ b/app/controllers/admin_data/public_controller.rb
@@ -8,20 +8,20 @@ module AdminData
         render :nothing => true, :status => 404 and return
       end
 
-      case params[:file]
-      when /\.css$/i
+      case params[:format].to_s.downcase
+      when 'css'
         content_type = "text/css"
-      when /\.js$/i
+      when 'js'
         content_type = "text/javascript"
-      when /\.png$/i
+      when 'png'
         content_type = "image/png"
-      when /\.jpg$/i
+      when 'jpg'
         content_type = "image/jpg"
       else
         render :nothing => true, :status => 404 and return
       end
 
-      render({:text => File.read(path), :cache => true, :content_type => content_type})
+      render({:text => File.read("#{path}.#{params[:format]}"), :cache => true, :content_type => content_type})
     end
 
   end

--- a/app/helpers/admin_data/application_helper.rb
+++ b/app/helpers/admin_data/application_helper.rb
@@ -23,7 +23,7 @@ module AdminData
     end
 
     def parent_layout(layout)
-      @_content_for[:layout] = self.output_buffer
+      content_for(:layout, self.output_buffer)
       self.output_buffer = render(:file => "layouts/#{layout}")
     end
 


### PR DESCRIPTION
After upgrading my app to Rails 3.1, I found that admin_data had some issues. Specifically with the `parent_layout` helper method and serving up the public files.

This is a quick and dirty fix to get things working. Eventually the assets should be redone to support the asset pipeline in 3.1. But this should get things working for now.
