### PR TITLE
Fixed an undefined method error in SearchController

### DIFF
--- a/app/controllers/admin_data/search_controller.rb
+++ b/app/controllers/admin_data/search_controller.rb
@@ -21,7 +21,7 @@ class SearchAction
 end
 
 module AdminData
-  class SearchController < ApplicationController
+  class SearchController < AdminData::ApplicationController
 
     layout 'search'
 


### PR DESCRIPTION
In Rails 3.2 when I try to visit /admin_data I get the following error:

NameError in AdminData::SearchController#quick_search

undefined local variable or method `get_class_from_params' for #AdminData::SearchController:0x007fe18dbd25d8

Adding the AdminData:: namespace to the inheritance fixed this issue.
