### PR TITLE
make stuff work with Rails 3.2.x

### DIFF
--- a/app/helpers/admin_data/application_helper.rb
+++ b/app/helpers/admin_data/application_helper.rb
@@ -306,7 +306,7 @@ module AdminData
     end
 
     def get_reflection_for_column(klass, col)
-      klass.reflections.values.detect { |reflection| reflection.primary_key_name.to_sym == col.name.to_sym }
+      klass.reflections.values.detect { |reflection| reflection.foreign_key.to_sym == col.name.to_sym }
     end
 
     def record_id(record)

--- a/lib/admin_data/version.rb
+++ b/lib/admin_data/version.rb
@@ -1,3 +1,3 @@
 module AdminData
-  VERSION = '1.2.1'
+  VERSION = '1.2.1a'
 end


### PR DESCRIPTION
Reflection#primary_key_name was removed in Rails 3.2.0
